### PR TITLE
fix typos

### DIFF
--- a/models/embedding/positional_encoding.py
+++ b/models/embedding/positional_encoding.py
@@ -7,7 +7,7 @@ import torch
 from torch import nn
 
 
-class PostionalEncoding(nn.Module):
+class PositionalEncoding(nn.Module):
     """
     compute sinusoid encoding.
     """
@@ -20,7 +20,7 @@ class PostionalEncoding(nn.Module):
         :param max_len: max sequence length
         :param device: hardware device setting
         """
-        super(PostionalEncoding, self).__init__()
+        super(PositionalEncoding, self).__init__()
 
         # same size with input matrix (for adding with input matrix)
         self.encoding = torch.zeros(max_len, d_model, device=device)

--- a/models/embedding/transformer_embedding.py
+++ b/models/embedding/transformer_embedding.py
@@ -5,7 +5,7 @@
 """
 from torch import nn
 
-from models.embedding.positional_encoding import PostionalEncoding
+from models.embedding.positional_encoding import PositionalEncoding
 from models.embedding.token_embeddings import TokenEmbedding
 
 
@@ -24,7 +24,7 @@ class TransformerEmbedding(nn.Module):
         """
         super(TransformerEmbedding, self).__init__()
         self.tok_emb = TokenEmbedding(vocab_size, d_model)
-        self.pos_emb = PostionalEncoding(d_model, max_len, device)
+        self.pos_emb = PositionalEncoding(d_model, max_len, device)
         self.drop_out = nn.Dropout(p=drop_prob)
 
     def forward(self, x):


### PR DESCRIPTION
I have read your code and found this typo: `PositionalEncoding` instead of `PostionalEncoding`. I tried replacing and re-running the code and it was fine (you can double-check in [my notebook](https://colab.research.google.com/drive/10e34kA0-eNCMddVlg0U78LfUPhHOqAs-?usp=sharing)). By the way, thanks for your great work.